### PR TITLE
Add support for custom cell renderer

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -5,39 +5,55 @@ import Component from '../../src'
 import faker from 'faker'
 import '../../dist/fixed-data-table.css';
 
-function getHeaders(){
+function getHeaders() {
 
- var columns = [
-	 {id:'id', name:'ID'},
-	 {id:'name', name:'Name'},
-	 {id:'address', name:'Street Address'},
-	 {id:'state', name:'State'},
-	 {id:'zip', name:'Zip Code'}
- ];
+  var columns = [
+    {
+      id: 'id',
+      name: 'ID'
+    }, {
+      id: 'name',
+      name: 'Name',
+      render: (name, row) => (
+        <a href={`https://duckduckgo.com/?q=${name} ${row['zip']}`} target='_blank'>{name}</a> 
+      )
+    }, {
+      id: 'address',
+      name: 'Street Address'
+    }, {
+      id: 'state',
+      name: 'State'
+    }, {
+      id: 'zip',
+      name: 'Zip Code'
+    }
+  ];
 
- return columns;
+  return columns;
 
 }
 
-function generateList(){
+function generateList() {
   var items = [];
 
-  for (var i=1; i<=5000; i++){
-   items.push({ id: i, name: faker.name.findName(), address: faker.address.streetAddress(), state: faker.address.stateAbbr(), zip: faker.address.zipCode()});
- }
+  for (var i = 1; i <= 5000; i++) {
+    items.push({id: i, name: faker.name.findName(), address: faker.address.streetAddress(), state: faker.address.stateAbbr(), zip: faker.address.zipCode()});
+  }
 
- return items;
+  return items;
 };
 
 const data = generateList();
 
 let Demo = React.createClass({
   render() {
-    return <div>
-    
-    <Component data={data} columns={getHeaders()} showColumnFilter={true} showDownloadButton={true} />
-    </div>
+    return (
+      <div>
+        <Component data={data} columns={getHeaders()} showColumnFilter={true} showDownloadButton={true}/>
+      </div>
+    );      
   }
 });
 
-render(<Demo/>, document.querySelector('#demo'))
+render(
+  <Demo/>, document.querySelector('#demo'))

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -11,19 +11,23 @@ function getHeaders() {
     {
       id: 'id',
       name: 'ID'
-    }, {
+    }, 
+    {
       id: 'name',
       name: 'Name',
       render: (name, row) => (
         <a href={`https://duckduckgo.com/?q=${name} ${row['zip']}`} target='_blank'>{name}</a> 
       )
-    }, {
+    }, 
+    {
       id: 'address',
       name: 'Street Address'
-    }, {
+    }, 
+    {
       id: 'state',
       name: 'State'
-    }, {
+    }, 
+    {
       id: 'zip',
       name: 'Zip Code'
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flybase-datagrid",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A React data grid component for FlyBase reports.",
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -138,11 +138,19 @@ class FlyBaseDataGrid extends Component {
                          </Header>
                        }
 
-                       cell={props => (
-                         <Cell {...props}>
-                           {items[props.rowIndex][column.id]}
-                         </Cell>
-                       )
+                       cell={
+                         (props) => {
+                           const row = items[props.rowIndex];
+                           let text = row[column.id];
+                           if (column.render) {
+                             text = column.render(text, row, column.id);
+                           }
+                           return (
+                             <Cell {...props}>
+                               {text}
+                             </Cell>
+                           )
+                         }
                        }
                      />
                     )


### PR DESCRIPTION
This change allows you to add a `render` field to a column definition. It should be a function that returns a string or a React element. The function will be passed the value of that cell, the current row, and current column id. Also updated the demo to show how to use it to render a link in a cell.